### PR TITLE
Fix code markup in WP.org's readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -20,20 +20,20 @@ This plugin adds repeatable groups of fields to Contact Form 7.
 Wrap the desired fields with `[field_group your_group_id_here][/field_group]`. The shortcode accepts additional parameters, in WP shortcode format and in CF7 fields parameters format as well.
 
 Example:
-```html
+~~~
 [field_group emails id="emails-groups" tabindex:1]
 	<label>Your Email (required)[email* your-email]</label>
 	[radio your-radio use_label_element default:1 "radio 1" "radio 2" "radio 3"]
 	[select* your-menu include_blank "option1" "option 2"]
 	[checkbox* your-checkbox "check 1" "check 2"]
 [/field_group]
-```
+~~~
 
 = Mail tab =
 In the mail settings, wrap the fields with your group id. You can use the `[group_index]` tag to print the group index and an additional `__<NUMBER>` to print a field at a specific index.
 
 Example:
-```html
+~~~
 The second email entered by the user was: [your-email__2]
 
 These were the groups:
@@ -44,7 +44,7 @@ GROUP #[group_index]
 	Radio: [your-radio]
 	Select: [your-menu]
 [/emails]
-```
+~~~
 
 == Check out the Wiki ==
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Different from GitHub, WP.org does not understand a block of text using ` 3 times. This PR reverts it back to use 3 ~ instead.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->