### PR TITLE
Applied 'wpcf7_field_group_content' filter to HTML output

### DIFF
--- a/class-cf7-repeatable-fields.php
+++ b/class-cf7-repeatable-fields.php
@@ -147,14 +147,15 @@ class CF7_Repeatable_Fields {
 			$group_id
 		);
 
-		return '<div ' . implode( ' ', $atts ) . '>' .
-			'<div class="wpcf7-field-group">' .
-				do_shortcode( $content ) .
+		return '<div ' . implode( ' ', $atts ) . '>' . apply_filters(
+				'wpcf7_field_group_content',
+				'<div class="wpcf7-field-group">' . do_shortcode( $content ) .
 				$remove_button .
 				$add_button .
-				'<input type="hidden" class="wpcf7-field-group-count" name="_wpcf7_groups_count[' . $group_id . ']" value="1" />' .
-			'</div>' .
-		'</div>';
+				'<input type="hidden" class="wpcf7-field-group-count" name="_wpcf7_groups_count[' . $group_id . ']" value="1" /></div>',
+			$group_id,
+			$this->groups[$group_id]
+		) . '</div>';
 	}
 
 	/**


### PR DESCRIPTION
Applied a filter so developers can potentially prepopulate with dynamic data. Example usage:

```
/**
 * Prepopulate Repeater Field
 *
 * @param string $default_html The full HTML content of the repeater group content.
 * @param string $group_name The field name representing the repeater group as set in the `field_group` form tag.
 * @param array $group An array of group data with keys for `tags` representing an array of scanned form tags and `raw` representing a string of raw HTML.
 *
 * @return string The full HTML content of the repeater group content.
 */
public function cf7_repeater_content($default_html, $group_name, $group)
{
    $prefilled_html = '';
    // Do stuff
    return $prefilled_content ? $prefilled_content : $default_html;
}```